### PR TITLE
Create cargo workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+**/*.rs.bk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_hive"
+version = "0.1.0"
+authors = ["Patricio Tula <tula.patricio@gmail.com>", "Julian Mateu <julianmateu@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Welcome to rust hive!");
+}


### PR DESCRIPTION
Adds the `.gitignore` and required files to use the [cargo package manager](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) with the project. The code can be built by running `cargo build`.